### PR TITLE
Update semji runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM docker:stable-dind
+FROM docker:20.10-dind
 
 RUN apk add --update alpine-sdk
-RUN apk add --update bash python python-dev py-pip libffi-dev build-base openssl-dev openssh jq rsync gcc libc-dev make gettext
+RUN apk add --update bash python3 python3-dev py-pip libffi-dev build-base openssl-dev openssh jq rsync gcc libc-dev make gettext rust cargo make
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util
 RUN pip install docker-compose
 RUN pip install awscli
@@ -15,9 +15,3 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 RUN curl -LO https://amazon-eks.s3-us-west-2.amazonaws.com/1.11.5/2018-12-06/bin/linux/amd64/aws-iam-authenticator && \
     chmod +x ./aws-iam-authenticator && \
     mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
-
-COPY start.sh /etc/start.sh
-
-RUN chmod +x /etc/start.sh
-
-CMD /etc/start.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# RVIP Gitlab Runner
+# Semji Gitlab Runner
+
+This repository contains the Dockerfile we use to build an optimized Docker image we use in our Gitlab CI runners.
+
+## Build
+
+On a classic x64 architecture, just drop the following command:
+
+```
+docker build -t semji/runner:latest .
+```
+
+If you're on a different architecture, such as ARM64 for examples, use buildx to build the image:
+
+```
+docker buildx build --platform linux/amd64 --tag semji/runner:latest --load .
+```
+
+## Push on Docker Hub
+
+```
+docker push semji/runner:latest
+```

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-eval `ssh-agent -s`
-dockerd


### PR DESCRIPTION
This PR updates Semji default Gitlab CI runner to the latest docker version.