### PR TITLE
Do not require dind anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,26 @@
-FROM docker:20.10-dind
+FROM docker:20.10
 
-RUN apk add --update alpine-sdk
-RUN apk add --update bash python3 python3-dev py-pip libffi-dev build-base openssl-dev openssh jq rsync gcc libc-dev make gettext rust cargo make zip npm
+RUN apk add --update \
+    alpine-sdk \
+    bash \
+    python3 python3-dev py-pip \
+    libffi-dev build-base openssl-dev openssh \
+    jq \
+    rsync \
+    gcc libc-dev make \
+    gettext \
+    rust \
+    cargo \
+    make \
+    zip \
+    npm
+
 RUN apk add -U --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing aufs-util
+
 RUN pip install docker-compose
+
 RUN pip install awscli
+
 RUN mkdir -p ~/.ssh/
 RUN echo -e "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null" > ~/.ssh/config
 


### PR DESCRIPTION
Our Gitlab projects now all use docker daemon as a service, therefore, we don't need to create an image based on dind.